### PR TITLE
GFETC-94 searching profile by userName instead of userId

### DIFF
--- a/TaskCat/TaskCat/Controller/Auth/AccountController.cs
+++ b/TaskCat/TaskCat/Controller/Auth/AccountController.cs
@@ -109,7 +109,7 @@
         /// <summary>
         /// View Public Profile on any user or asset
         /// </summary>
-        /// <param name="userId">
+        /// <param name="userName">
         /// User Id for user or asset
         /// </param>
         /// <returns>
@@ -117,26 +117,26 @@
         /// </returns>
         [AllowAnonymous]
         [Authorize(Roles = "Administrator, BackOfficeAdmin, User, Asset")]
-        [Route("Profile/{userId?}")]
+        [Route("Profile/{userName?}")]
         [HttpGet]
-        public async Task<IHttpActionResult> Profile(string userId = null)
+        public async Task<IHttpActionResult> Profile(string userName = null)
         {
             try
             {
-                if (!this.User.Identity.IsAuthenticated && string.IsNullOrEmpty(userId))
+                if (!this.User.Identity.IsAuthenticated && string.IsNullOrEmpty(userName))
                     return BadRequest("To get a public profile, please provide a valid user Id");
 
-                if (string.IsNullOrWhiteSpace(userId))
-                    userId = this.User.Identity.GetUserId();
+                if (string.IsNullOrWhiteSpace(userName))
+                    userName = this.User.Identity.GetUserName();
 
-                var userModel = await authRepository.FindUserAsModel(userId);
+                var userModel = await authRepository.FindUserAsModel(userName);
                 if (userModel == null) return NotFound();
 
                 if (this.User.Identity.IsAuthenticated)
                 {
                     if (this.User.IsInRole("Administrator") || this.User.IsInRole("BackOfficeAdmin"))
                         userModel.IsUserAuthenticated = true;
-                    else if ((this.User.IsInRole("User") || this.User.IsInRole("Asset")) && (this.User.Identity.GetUserId() == userId))
+                    else if ((this.User.IsInRole("User") || this.User.IsInRole("Asset")) && (this.User.Identity.GetUserName() == userName))
                         userModel.IsUserAuthenticated = true;
                 }
 

--- a/TaskCat/TaskCat/Lib/Auth/AuthRepository.cs
+++ b/TaskCat/TaskCat/Lib/Auth/AuthRepository.cs
@@ -235,14 +235,14 @@
             return await accountManager.UpdateAsync(user);
         }
 
-        internal async Task<User> FindUser(string userId)
+        internal async Task<User> FindUser(string userName)
         {
-            return await accountManager.FindByIdAsync(userId);
+            return await accountManager.FindByNameAsync(userName);
         }
 
-        internal async Task<UserModel> FindUserAsModel(string userId)
+        internal async Task<UserModel> FindUserAsModel(string userName)
         {
-            var user = await FindUser(userId);
+            var user = await FindUser(userName);
 
             //FIXME: Someday I can use a factory here
             if (user.Type == IdentityTypes.USER)


### PR DESCRIPTION
Searching a user profile by userName is much easier than searching it by a 24 character userId. The asset needs to ping its location with userId, but it knows nothing more than its userName and password. So replaced the profile search param from userId to userName.